### PR TITLE
Fixes for rustc nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,13 +2,13 @@
 name = "chip8"
 version = "0.0.1"
 dependencies = [
- "piston2d-graphics 0.0.9 (git+https://github.com/pistondevelopers/graphics)",
+ "piston2d-graphics 0.0.13 (git+https://github.com/pistondevelopers/graphics)",
  "piston2d-opengl_graphics 0.0.6 (git+https://github.com/pistondevelopers/opengl_graphics)",
- "pistoncore-event 0.0.7 (git+https://github.com/pistondevelopers/event)",
+ "pistoncore-event 0.0.8 (git+https://github.com/pistondevelopers/event)",
  "pistoncore-input 0.0.5 (git+https://github.com/pistondevelopers/input)",
- "pistoncore-sdl2_window 0.0.3 (git+https://github.com/pistondevelopers/sdl2_window)",
- "pistoncore-window 0.0.5 (git+https://github.com/pistondevelopers/window)",
- "quack 0.0.8 (git+https://github.com/pistondevelopers/quack)",
+ "pistoncore-sdl2_window 0.0.4 (git+https://github.com/pistondevelopers/sdl2_window)",
+ "pistoncore-window 0.0.7 (git+https://github.com/pistondevelopers/window)",
+ "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
  "shader_version 0.0.1 (git+https://github.com/pistondevelopers/shader_version)",
 ]
 
@@ -43,46 +43,46 @@ dependencies = [
 [[package]]
 name = "gl"
 version = "0.0.7"
-source = "git+https://github.com/bjz/gl-rs#c5303f86a9aac5392bae959b21a8af84e86510e3"
+source = "git+https://github.com/bjz/gl-rs#304569673d345b7b752aff2242f6926043e47b46"
 dependencies = [
  "gl_common 0.0.3 (git+https://github.com/bjz/gl-rs)",
- "gl_generator 0.0.13 (git+https://github.com/bjz/gl-rs)",
+ "gl_generator 0.0.14 (git+https://github.com/bjz/gl-rs)",
  "khronos_api 0.0.5 (git+https://github.com/bjz/gl-rs)",
 ]
 
 [[package]]
 name = "gl_common"
 version = "0.0.3"
-source = "git+https://github.com/bjz/gl-rs#c5303f86a9aac5392bae959b21a8af84e86510e3"
+source = "git+https://github.com/bjz/gl-rs#304569673d345b7b752aff2242f6926043e47b46"
 
 [[package]]
 name = "gl_generator"
-version = "0.0.13"
-source = "git+https://github.com/bjz/gl-rs#c5303f86a9aac5392bae959b21a8af84e86510e3"
+version = "0.0.14"
+source = "git+https://github.com/bjz/gl-rs#304569673d345b7b752aff2242f6926043e47b46"
 dependencies = [
  "gl_common 0.0.3 (git+https://github.com/bjz/gl-rs)",
  "khronos_api 0.0.5 (git+https://github.com/bjz/gl-rs)",
- "log 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "image"
 version = "0.2.0-alpha.8"
-source = "git+https://github.com/pistondevelopers/image#b29d070644cd51f3e33001e58817087cae1dd63d"
+source = "git+https://github.com/pistondevelopers/image#db5fdba858bd799722485004f3f2a06e27ca5c88"
 dependencies = [
- "num 0.1.10 (git+https://github.com/rust-lang/num)",
+ "num 0.1.12 (git+https://github.com/rust-lang/num)",
 ]
 
 [[package]]
 name = "interpolation"
 version = "0.0.1"
-source = "git+https://github.com/PistonDevelopers/interpolation#81b572b9bf1b8aaaf3a9531d9d597e057ff12c2c"
+source = "git+https://github.com/PistonDevelopers/interpolation#056dfca4c3ca0b477eba7efb038ee03c5515b28e"
 
 [[package]]
 name = "khronos_api"
 version = "0.0.5"
-source = "git+https://github.com/bjz/gl-rs#c5303f86a9aac5392bae959b21a8af84e86510e3"
+source = "git+https://github.com/bjz/gl-rs#304569673d345b7b752aff2242f6926043e47b46"
 
 [[package]]
 name = "khronos_api"
@@ -99,30 +99,30 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num"
-version = "0.1.10"
-source = "git+https://github.com/rust-lang/num#c05cd530dbc1cc2e56f936524400b368e07ee5cb"
+version = "0.1.12"
+source = "git+https://github.com/rust-lang/num#0811c72bacce6d8adc7a25be8292ba55f4118d9e"
 dependencies = [
- "rustc-serialize 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piston-texture"
 version = "0.0.1"
-source = "git+https://github.com/PistonDevelopers/texture#0380876cec71e384841d5a06ad32cb462c97be20"
+source = "git+https://github.com/pistondevelopers/texture#0380876cec71e384841d5a06ad32cb462c97be20"
 
 [[package]]
 name = "piston2d-graphics"
-version = "0.0.9"
-source = "git+https://github.com/pistondevelopers/graphics#912d58aa013279f6524ba5f8887983103fa2d468"
+version = "0.0.13"
+source = "git+https://github.com/pistondevelopers/graphics#79955a7afad59dd02a98f35266c9a93ef6b30915"
 dependencies = [
  "interpolation 0.0.1 (git+https://github.com/PistonDevelopers/interpolation)",
- "piston-texture 0.0.1 (git+https://github.com/PistonDevelopers/texture)",
- "quack 0.0.8 (git+https://github.com/pistondevelopers/quack)",
+ "piston-texture 0.0.1 (git+https://github.com/pistondevelopers/texture)",
+ "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
  "read_color 0.0.2 (git+https://github.com/PistonDevelopers/read_color)",
  "vecmath 0.0.3 (git+https://github.com/PistonDevelopers/vecmath)",
 ]
@@ -130,34 +130,34 @@ dependencies = [
 [[package]]
 name = "piston2d-opengl_graphics"
 version = "0.0.6"
-source = "git+https://github.com/pistondevelopers/opengl_graphics#b2f8663e5b2aebb2be09d76533881393f1aa2068"
+source = "git+https://github.com/pistondevelopers/opengl_graphics#582310d8ce7511e7d2ec23f324afd92a515437ae"
 dependencies = [
  "freetype-rs 0.0.6 (git+https://github.com/PistonDevelopers/freetype-rs.git)",
  "gl 0.0.7 (git+https://github.com/bjz/gl-rs)",
  "image 0.2.0-alpha.8 (git+https://github.com/pistondevelopers/image)",
  "khronos_api 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston-texture 0.0.1 (git+https://github.com/PistonDevelopers/texture)",
- "piston2d-graphics 0.0.9 (git+https://github.com/pistondevelopers/graphics)",
+ "piston-texture 0.0.1 (git+https://github.com/pistondevelopers/texture)",
+ "piston2d-graphics 0.0.13 (git+https://github.com/pistondevelopers/graphics)",
  "shader_version 0.0.1 (git+https://github.com/pistondevelopers/shader_version)",
 ]
 
 [[package]]
 name = "pistoncore-event"
-version = "0.0.7"
-source = "git+https://github.com/pistondevelopers/event#ade8ab2956fc4b6d77135f586d390b5e9ad455e4"
+version = "0.0.8"
+source = "git+https://github.com/pistondevelopers/event#96afe0074416bf22478149b6a17979d633fc4375"
 dependencies = [
- "pistoncore-event_loop 0.0.7 (git+https://github.com/pistondevelopers/event_loop)",
+ "pistoncore-event_loop 0.0.10 (git+https://github.com/pistondevelopers/event_loop)",
  "pistoncore-input 0.0.5 (git+https://github.com/pistondevelopers/input)",
- "pistoncore-window 0.0.5 (git+https://github.com/pistondevelopers/window)",
+ "pistoncore-window 0.0.7 (git+https://github.com/pistondevelopers/window)",
 ]
 
 [[package]]
 name = "pistoncore-event_loop"
-version = "0.0.7"
-source = "git+https://github.com/pistondevelopers/event_loop#21fda1372948f7f1413f975ada86506325395844"
+version = "0.0.10"
+source = "git+https://github.com/pistondevelopers/event_loop#50dc05477eaccb3b64535cd17eae26e9108bd703"
 dependencies = [
  "clock_ticks 0.0.2 (git+https://github.com/tomaka/clock_ticks)",
- "quack 0.0.8 (git+https://github.com/pistondevelopers/quack)",
+ "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
 ]
 
 [[package]]
@@ -166,30 +166,30 @@ version = "0.0.5"
 source = "git+https://github.com/pistondevelopers/input#ce3ba43c2757b20a8fc5b92e9ec388e927c451dd"
 dependencies = [
  "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pistoncore-sdl2_window"
-version = "0.0.3"
-source = "git+https://github.com/pistondevelopers/sdl2_window#cd6d43c83e482dc2c71d95827cbdd7f7fa96ebb3"
+version = "0.0.4"
+source = "git+https://github.com/pistondevelopers/sdl2_window#f674c7988e8c84b807b917e5b46240f0e55080d7"
 dependencies = [
  "gl 0.0.7 (git+https://github.com/bjz/gl-rs)",
  "pistoncore-input 0.0.5 (git+https://github.com/pistondevelopers/input)",
- "pistoncore-window 0.0.5 (git+https://github.com/pistondevelopers/window)",
- "quack 0.0.8 (git+https://github.com/pistondevelopers/quack)",
- "sdl2 0.0.22 (git+https://github.com/AngryLawyer/rust-sdl2)",
+ "pistoncore-window 0.0.7 (git+https://github.com/pistondevelopers/window)",
+ "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
+ "sdl2 0.0.24 (git+https://github.com/AngryLawyer/rust-sdl2)",
  "shader_version 0.0.1 (git+https://github.com/pistondevelopers/shader_version)",
 ]
 
 [[package]]
 name = "pistoncore-window"
-version = "0.0.5"
-source = "git+https://github.com/pistondevelopers/window#f3c91e7c4ddd4265d80455158bdcc73f80eaebec"
+version = "0.0.7"
+source = "git+https://github.com/pistondevelopers/window#2e743eb16a74fc8577c5779a86b6eed20fe470fd"
 dependencies = [
- "pistoncore-event_loop 0.0.7 (git+https://github.com/pistondevelopers/event_loop)",
+ "pistoncore-event_loop 0.0.10 (git+https://github.com/pistondevelopers/event_loop)",
  "pistoncore-input 0.0.5 (git+https://github.com/pistondevelopers/input)",
- "quack 0.0.8 (git+https://github.com/pistondevelopers/quack)",
+ "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
 ]
 
 [[package]]
@@ -199,8 +199,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quack"
-version = "0.0.8"
-source = "git+https://github.com/pistondevelopers/quack#c5230baef8e53b51f22c5d1eb2ac6f23b1e9e7ee"
+version = "0.0.10"
+source = "git+https://github.com/pistondevelopers/quack#f0336126611d352a529ffd4e86134a7a6bcc5318"
 
 [[package]]
 name = "read_color"
@@ -209,22 +209,22 @@ source = "git+https://github.com/PistonDevelopers/read_color#568723fb7d9a69833e1
 
 [[package]]
 name = "rustc-serialize"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sdl2"
-version = "0.0.22"
-source = "git+https://github.com/AngryLawyer/rust-sdl2#f12192caf70429c183877280ba10c1acd4c5924e"
+version = "0.0.24"
+source = "git+https://github.com/AngryLawyer/rust-sdl2#d40c74913ff1a5c752ac17a58159a2ef5051fc62"
 dependencies = [
  "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sdl2-sys 0.0.22 (git+https://github.com/AngryLawyer/rust-sdl2)",
+ "sdl2-sys 0.0.23 (git+https://github.com/AngryLawyer/rust-sdl2)",
 ]
 
 [[package]]
 name = "sdl2-sys"
-version = "0.0.22"
-source = "git+https://github.com/AngryLawyer/rust-sdl2#f12192caf70429c183877280ba10c1acd4c5924e"
+version = "0.0.23"
+source = "git+https://github.com/AngryLawyer/rust-sdl2#d40c74913ff1a5c752ac17a58159a2ef5051fc62"
 dependencies = [
  "pkg-config 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -241,7 +241,7 @@ source = "git+https://github.com/PistonDevelopers/vecmath#3080ca140d4f856b7a6ca4
 
 [[package]]
 name = "xml-rs"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(test, allow(dead_code))]
 
 // TODO revisit these after 1.0.0beta
-#![feature(collections)]
 #![feature(core)]
 #![feature(io)]
 #![feature(os)]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -44,7 +44,7 @@ impl Op {
     }
 }
 
-#[derive(Show)]
+#[derive(Debug)]
 pub enum Instruction {
     Sys(Addr),              // 0nnn - SYS addr
     Clear,                  // 00E0 - CLS


### PR DESCRIPTION
I've tried running the current `HEAD` with today's `rustc`:

``` sh
$ rustc --version
rustc 1.0.0-nightly (eaf4c5c78 2015-02-02 15:04:54 +0000)
```

Yet the dependencies would not compile at all, so I did a `cargo --update`.
Next I'd get one compiler error and one warning:

```
src/ops.rs:47:10: 47:14 warning: derive(Show) is deprecated in favor of derive(Debug)
src/ops.rs:47 #[derive(Show)]
                       ^~~~
src/main.rs:4:12: 4:23 error: unused or unknown feature, #[deny(unused_features)] on by default
src/main.rs:4 #![feature(collections)]
                         ^~~~~~~~~~~
```

With those changes in place the compiled binary and unit tests work. Let's see how long :smile: 
