### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,16 +28,16 @@ version = "0.0.6"
 source = "git+https://github.com/PistonDevelopers/freetype-rs.git#b03afd3259e3ca36bf3d3dd8589b760b604e6aff"
 dependencies = [
  "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "freetype-sys 0.0.2 (git+https://github.com/PistonDevelopers/freetype-sys)",
+ "freetype-sys 0.0.3 (git+https://github.com/PistonDevelopers/freetype-sys)",
 ]
 
 [[package]]
 name = "freetype-sys"
-version = "0.0.2"
-source = "git+https://github.com/PistonDevelopers/freetype-sys#b0c1eaa34b0d1c5689de94cb94a3f87cd22a46db"
+version = "0.0.3"
+source = "git+https://github.com/PistonDevelopers/freetype-sys#2a26c21bae00bb467366e1333bfd2ecb8012b0cf"
 dependencies = [
  "libz-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -68,8 +68,8 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.2.0-alpha.8"
-source = "git+https://github.com/pistondevelopers/image#db5fdba858bd799722485004f3f2a06e27ca5c88"
+version = "0.2.0-alpha.9"
+source = "git+https://github.com/pistondevelopers/image#b7aff0a1ad2b6b0bdc04c1a7731d502606cbafb3"
 dependencies = [
  "num 0.1.12 (git+https://github.com/rust-lang/num)",
 ]
@@ -90,6 +90,11 @@ version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libz-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,9 +110,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "num"
 version = "0.1.12"
-source = "git+https://github.com/rust-lang/num#0811c72bacce6d8adc7a25be8292ba55f4118d9e"
+source = "git+https://github.com/rust-lang/num#e2f0b0d3270554d336c5908bb20a6cbbc0754e61"
 dependencies = [
- "rustc-serialize 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -134,7 +140,7 @@ source = "git+https://github.com/pistondevelopers/opengl_graphics#582310d8ce7511
 dependencies = [
  "freetype-rs 0.0.6 (git+https://github.com/PistonDevelopers/freetype-rs.git)",
  "gl 0.0.7 (git+https://github.com/bjz/gl-rs)",
- "image 0.2.0-alpha.8 (git+https://github.com/pistondevelopers/image)",
+ "image 0.2.0-alpha.9 (git+https://github.com/pistondevelopers/image)",
  "khronos_api 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-texture 0.0.1 (git+https://github.com/pistondevelopers/texture)",
  "piston2d-graphics 0.0.13 (git+https://github.com/pistondevelopers/graphics)",
@@ -146,7 +152,7 @@ name = "pistoncore-event"
 version = "0.0.8"
 source = "git+https://github.com/pistondevelopers/event#96afe0074416bf22478149b6a17979d633fc4375"
 dependencies = [
- "pistoncore-event_loop 0.0.10 (git+https://github.com/pistondevelopers/event_loop)",
+ "pistoncore-event_loop 0.0.10 (git+https://github.com/PistonDevelopers/event_loop)",
  "pistoncore-input 0.0.5 (git+https://github.com/pistondevelopers/input)",
  "pistoncore-window 0.0.7 (git+https://github.com/pistondevelopers/window)",
 ]
@@ -154,7 +160,7 @@ dependencies = [
 [[package]]
 name = "pistoncore-event_loop"
 version = "0.0.10"
-source = "git+https://github.com/pistondevelopers/event_loop#50dc05477eaccb3b64535cd17eae26e9108bd703"
+source = "git+https://github.com/PistonDevelopers/event_loop#50dc05477eaccb3b64535cd17eae26e9108bd703"
 dependencies = [
  "clock_ticks 0.0.2 (git+https://github.com/tomaka/clock_ticks)",
  "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
@@ -166,7 +172,7 @@ version = "0.0.5"
 source = "git+https://github.com/pistondevelopers/input#ce3ba43c2757b20a8fc5b92e9ec388e927c451dd"
 dependencies = [
  "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -187,7 +193,7 @@ name = "pistoncore-window"
 version = "0.0.7"
 source = "git+https://github.com/pistondevelopers/window#2e743eb16a74fc8577c5779a86b6eed20fe470fd"
 dependencies = [
- "pistoncore-event_loop 0.0.10 (git+https://github.com/pistondevelopers/event_loop)",
+ "pistoncore-event_loop 0.0.10 (git+https://github.com/PistonDevelopers/event_loop)",
  "pistoncore-input 0.0.5 (git+https://github.com/pistondevelopers/input)",
  "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
 ]
@@ -198,9 +204,23 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pkg-config"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "quack"
 version = "0.0.10"
 source = "git+https://github.com/pistondevelopers/quack#f0336126611d352a529ffd4e86134a7a6bcc5318"
+
+[[package]]
+name = "rand"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "read_color"
@@ -209,7 +229,7 @@ source = "git+https://github.com/PistonDevelopers/read_color#568723fb7d9a69833e1
 
 [[package]]
 name = "rustc-serialize"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]


### PR DESCRIPTION
More breakage with the new nightly;

```
$ rustc --version
rustc 1.0.0-nightly (ba2f13ef0 2015-02-04 20:03:55 +0000)
```

Again, this is just me running `cargo update`.
