### PR TITLE
Rename `Ch8Error` to `Chip8Error`

### DIFF
--- a/chip8_vm/src/error.rs
+++ b/chip8_vm/src/error.rs
@@ -2,35 +2,33 @@ use std::fmt;
 use std::old_io::{IoError};
 use std::error::{Error, FromError};
 
-pub enum Ch8Error {
+pub enum Chip8Error {
     Io(&'static str, Option<IoError>),
 }
 
-impl fmt::Display for Ch8Error {
+impl fmt::Display for Chip8Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         return write!(fmt, "{}", self.description())
     }
 }
 
-impl Error for Ch8Error {
+impl Error for Chip8Error {
     fn description(&self) -> &str {
-        use self::Ch8Error::*;
         match *self {
-            Io(desc, _) => desc
+            Chip8Error::Io(desc, _) => desc,
         }
     }
 
     fn cause(&self) -> Option<&Error> {
-        use self::Ch8Error::*;
         match *self {
-            Io(_, Some(ref cause)) => Some(cause),
-            _ => None
+            Chip8Error::Io(_, Some(ref cause)) => Some(cause),
+            _ => None,
         }
     }
 }
 
-impl FromError<IoError> for Ch8Error {
-    fn from_error(err: IoError) -> Ch8Error {
-        Ch8Error::Io("Internal IO error: ", Some(err))
+impl FromError<IoError> for Chip8Error {
+    fn from_error(err: IoError) -> Chip8Error {
+        Chip8Error::Io("Internal IO error: ", Some(err))
     }
 }

--- a/chip8_vm/src/vm.rs
+++ b/chip8_vm/src/vm.rs
@@ -2,7 +2,7 @@ extern crate rand;
 
 use std::old_io::{BufWriter, Reader};
 // use std::num::Float;
-use error::Ch8Error;
+use error::Chip8Error;
 use ops::{Op, Instruction};
 use std::slice::Chunks;
 
@@ -83,11 +83,11 @@ impl Vm {
         vm
     }
 
-    pub fn load_rom(&mut self, reader: &mut Reader) -> Result<usize, Ch8Error> {
+    pub fn load_rom(&mut self, reader: &mut Reader) -> Result<usize, Chip8Error> {
         let rom = try!(reader.read_to_end());
         if rom.len() > (RAM_SIZE - PROGRAM_START) {
             println!("Rom size {}", rom.len());
-            return Err(Ch8Error::Io("Rom was larger than available RAM", None))
+            return Err(Chip8Error::Io("ROM was larger than available RAM", None))
         }
         let mut ram = BufWriter::new(&mut self.ram[PROGRAM_START..RAM_SIZE]);
         try!(ram.write_all(rom.as_slice()));


### PR DESCRIPTION
As I do not see a reason to use a shortened `Ch8` name here, I expanded it into `Chip8`.
