### PR TITLE
Add continous integration via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: rust
+before_install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq libsdl2-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: rust
 before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libsdl2-dev
+    - sudo apt-get install build-essential xorg-dev libudev-dev libts-dev libgl1-mesa-dev libglu1-mesa-dev libasound2-dev libpulse-dev libopenal-dev libogg-dev libvorbis-dev libaudiofile-dev libpng12-dev libfreetype6-dev libusb-dev libdbus-1-dev zlib1g-dev libdirectfb-dev
+    - wget http://www.libsdl.org/release/SDL2-2.0.3.tar.gz
+    - tar -xvzf SDL2-2.0.3.tar.gz
+    - cd SDL2-2.0.3/ && ./configure && make && sudo make install && sudo ldconfig

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ See the [chip8_vm](https://github.com/chip8-rust/chip8-rust/tree/master/chip8_vm
 
 Status
 ==
+[![Build Status](https://travis-ci.org/chip8-rust/chip8-rust.svg?branch=master)](https://travis-ci.org/chip8-rust/chip8-rust)
 * Graphics are implemented with [Piston](http://www.piston.rs/).
 * Sound is not supported but is faked by updating the title bar with a note
 symbol when sound should be playing.


### PR DESCRIPTION
I have enabled `Travis CI` as a Service for this repository and also enabled the repository on Travis itself.

Unlike the Piston docs (from our README) say, one can not just `sudo apt-get install libsdl2-dev` on Travis, since they're running Ubuntu 12.04 LTS, so I'm building and installing SDL2 (2.03) from source.

The builds are failing, but this is due to `rustc` nightly updates and happens on my local machine as well.

This pull request implements the Travis CI part of #8.
