### PR TITLE
Mention rustdoc URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "chip8_ui"
 version = "0.0.1"
 dependencies = [
- "chip8_vm 0.0.1",
+ "chip8_vm 0.0.2",
  "piston2d-graphics 0.0.14 (git+https://github.com/pistondevelopers/graphics)",
  "piston2d-opengl_graphics 0.0.6 (git+https://github.com/pistondevelopers/opengl_graphics)",
  "pistoncore-event 0.0.8 (git+https://github.com/pistondevelopers/event)",
@@ -20,7 +20,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chip8_vm"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "rand 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/chip8_vm/Cargo.toml
+++ b/chip8_vm/Cargo.toml
@@ -7,7 +7,8 @@ license = "MIT"
 keywords = ["vm", "chip-8",]
 homepage = "https://github.com/chip8-rust/chip8-rust"
 repository = "https://github.com/chip8-rust/chip8-rust.git"
-version = "0.0.1"
+documentation = "https://chip8-rust.github.io/chip8-rust/chip8_vm/"
+version = "0.0.2"
 authors = [
     "Jake Kerr <kodafox@gmail.com>",
     "robo9k <robo@9k.lv>",

--- a/chip8_vm/README.md
+++ b/chip8_vm/README.md
@@ -26,7 +26,8 @@ To depend on the development version:
 git = "https://github.com/chip8-rust/chip8-rust"
 ```
 
-See an example integration with a UI in the [chip8_ui](https://github.com/chip8-rust/chip8-rust/blob/master/src/main.rs) crate.
+See an example integration with a UI in the [chip8_ui](https://github.com/chip8-rust/chip8-rust/blob/master/src/main.rs) crate code.
+For further information, take a look at the [`chip8_vm` rustdoc](https://chip8-rust.github.io/chip8-rust/chip8_vm/).
 
 Spec
 ==


### PR DESCRIPTION
This adds the `rustdoc` location from #5 to `chip8_vm`'s metadata as well as its `README`.
