### PR TITLE
Rename `Op` to `RawInstruction`

### DIFF
--- a/chip8_vm/src/instructions.rs
+++ b/chip8_vm/src/instructions.rs
@@ -45,12 +45,12 @@ impl RawInstruction {
         self.bits & 0x0FFF
     }
 
-    /// The *index of the `Vx` register* part
+    /// The *`Vx` register-index* part, i.e. `0xE` is `VE`
     pub fn x(&self) -> Vx {
         ((self.bits & 0x0F00) >> 8) as u8
     }
 
-    /// The *index of the `Vy` register* part
+    /// The *`Vy` register-index* part, i.e. `0xE` is `VE`
     pub fn y(&self) -> Vy {
         ((self.bits & 0x00F0) >> 4) as u8
     }

--- a/chip8_vm/src/lib.rs
+++ b/chip8_vm/src/lib.rs
@@ -6,8 +6,9 @@
 //! and so on.
 //!
 //!
-//! The code is split into the `ops` module, which provides
-//! the translation from opcodes (`Op`) into instructions (`Instruction`).
+//! The code is split into the `instructions` module, which provides
+//! the translation from raw bits (`RawInstruction`) into valid
+//! instructions (`Instruction`).
 //!
 //! The `vm` module contains the actual virtual machine implementation
 //! (`Vm`) and a few shared constants.
@@ -26,5 +27,7 @@
 extern crate rand;
 
 pub mod error;
-pub mod ops;
+pub mod instructions;
 pub mod vm;
+
+pub use instructions::*;

--- a/chip8_vm/src/vm.rs
+++ b/chip8_vm/src/vm.rs
@@ -409,7 +409,7 @@ impl Vm {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ops::*;
+    use instructions::*;
 
     macro_rules! reg_test {
         (

--- a/chip8_vm/src/vm.rs
+++ b/chip8_vm/src/vm.rs
@@ -5,7 +5,7 @@ extern crate rand;
 use std::old_io::{BufWriter, Reader};
 // use std::num::Float;
 use error::Chip8Error;
-use ops::{Op, Instruction};
+use instructions::{RawInstruction, Instruction};
 use std::slice::Chunks;
 
 use rand::Rng;
@@ -123,9 +123,11 @@ impl Vm {
     }
 
     fn exec(&mut self, ins: &Instruction) -> bool {
-        use ops::Instruction::*;
+        use instructions::Instruction::*;
+
         match *ins {
             // Sys(addr) intentionally left unimplemented.
+
             Clear => {
                 for b in self.screen.iter_mut() {
                     *b = 0;
@@ -359,9 +361,9 @@ impl Vm {
                 let codes = &self.ram[self.pc..self.pc+2];
                 ((codes[0] as u16) << 8) | codes[1] as u16
             };
-            let op = Op::new(raw);
+            let raw_ins = RawInstruction::new(raw);
             self.pc += 2;
-            self.exec(&Instruction::from_op(&op));
+            self.exec(&Instruction::from_raw(&raw_ins));
         }
     }
 
@@ -388,15 +390,15 @@ impl Vm {
             match i {
                 [0, 0] => continue,
                 [h, l] => {
-                    let op = Op::new(((h as u16) << 8) | l as u16);
-                    println!("raw: 0x{:X}", op.raw());
-                    println!("instruction: {:?}", Instruction::from_op(&op));
-                    println!("addr: 0x{:X}", op.addr());
-                    println!("x: 0x{:X}", op.x());
-                    println!("y: 0x{:X}", op.y());
-                    println!("n_high: 0x{:X}", op.n_high());
-                    println!("n_low: 0x{:X}", op.n_low());
-                    println!("k: 0x{:X}\n", op.k());
+                    let raw_ins = RawInstruction::new(((h as u16) << 8) | l as u16);
+                    println!("raw bits: 0x{:X}", raw_ins.bits());
+                    println!("instruction: {:?}", Instruction::from_raw(&raw_ins));
+                    println!("addr: 0x{:X}", raw_ins.addr());
+                    println!("x: 0x{:X}", raw_ins.x());
+                    println!("y: 0x{:X}", raw_ins.y());
+                    println!("n_high: 0x{:X}", raw_ins.n_high());
+                    println!("n_low: 0x{:X}", raw_ins.n_low());
+                    println!("k: 0x{:X}\n", raw_ins.k());
                 },
                 _ => continue
             }


### PR DESCRIPTION
Add more rustdoc,
rename the `ops` module to `instructions` and re-export it for easier use.

This is a first draft to fix #17 
