### PR TITLE
Use new `std::io` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,14 +2,14 @@
 name = "chip8_ui"
 version = "0.0.1"
 dependencies = [
- "chip8_vm 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston2d-graphics 0.0.17 (git+https://github.com/pistondevelopers/graphics)",
+ "chip8_vm 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-graphics 0.0.18 (git+https://github.com/pistondevelopers/graphics)",
  "piston2d-opengl_graphics 0.0.8 (git+https://github.com/pistondevelopers/opengl_graphics)",
- "pistoncore-event 0.0.8 (git+https://github.com/pistondevelopers/event)",
+ "pistoncore-event 0.0.10 (git+https://github.com/pistondevelopers/event)",
  "pistoncore-input 0.0.5 (git+https://github.com/pistondevelopers/input)",
- "pistoncore-sdl2_window 0.0.4 (git+https://github.com/pistondevelopers/sdl2_window)",
- "pistoncore-window 0.0.7 (git+https://github.com/pistondevelopers/window)",
- "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
+ "pistoncore-sdl2_window 0.0.5 (git+https://github.com/pistondevelopers/sdl2_window)",
+ "pistoncore-window 0.0.10 (git+https://github.com/pistondevelopers/window)",
+ "quack 0.0.12 (git+https://github.com/pistondevelopers/quack)",
  "shader_version 0.0.1 (git+https://github.com/pistondevelopers/shader_version)",
 ]
 
@@ -20,10 +20,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chip8_vm"
-version = "0.0.3"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -34,7 +34,7 @@ source = "git+https://github.com/tomaka/clock_ticks#75347002bc4fee853b385da8d3b5
 [[package]]
 name = "freetype-rs"
 version = "0.0.6"
-source = "git+https://github.com/PistonDevelopers/freetype-rs.git#c0e1793f6d7e45ad04db75349bb5180ab1e9e7de"
+source = "git+https://github.com/PistonDevelopers/freetype-rs.git#64614fdbbc78b9433446f99f50d3fab58d75427e"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype-sys 0.0.3 (git+https://github.com/PistonDevelopers/freetype-sys)",
@@ -48,16 +48,16 @@ source = "git+https://github.com/PistonDevelopers/freetype-sys#45615f83607a4e9e0
 dependencies = [
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gl"
 version = "0.0.8"
-source = "git+https://github.com/bjz/gl-rs#64d26f54d46640eff237db9e1aba4254ca514daf"
+source = "git+https://github.com/bjz/gl-rs#9d941381c5947bbbbe93ad6651e8eddd1c293dce"
 dependencies = [
  "gl_common 0.0.4 (git+https://github.com/bjz/gl-rs)",
- "gl_generator 0.0.17 (git+https://github.com/bjz/gl-rs)",
+ "gl_generator 0.0.18 (git+https://github.com/bjz/gl-rs)",
  "khronos_api 0.0.5 (git+https://github.com/bjz/gl-rs)",
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -65,38 +65,38 @@ dependencies = [
 [[package]]
 name = "gl_common"
 version = "0.0.4"
-source = "git+https://github.com/bjz/gl-rs#64d26f54d46640eff237db9e1aba4254ca514daf"
+source = "git+https://github.com/bjz/gl-rs#9d941381c5947bbbbe93ad6651e8eddd1c293dce"
 dependencies = [
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gl_generator"
-version = "0.0.17"
-source = "git+https://github.com/bjz/gl-rs#64d26f54d46640eff237db9e1aba4254ca514daf"
+version = "0.0.18"
+source = "git+https://github.com/bjz/gl-rs#9d941381c5947bbbbe93ad6651e8eddd1c293dce"
 dependencies = [
  "khronos_api 0.0.5 (git+https://github.com/bjz/gl-rs)",
- "log 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "image"
 version = "0.2.0-alpha.10"
-source = "git+https://github.com/pistondevelopers/image#5b589d98e53da920a28dbed8b3ea83452280cdd2"
+source = "git+https://github.com/pistondevelopers/image#7ed0daee0ced910bcd111a9c88158da149151260"
 dependencies = [
- "num 0.1.12 (git+https://github.com/rust-lang/num)",
+ "num 0.1.14 (git+https://github.com/rust-lang/num)",
 ]
 
 [[package]]
 name = "interpolation"
 version = "0.0.2"
-source = "git+https://github.com/PistonDevelopers/interpolation#e31859f6d63fad2469c55829e478d988b3441a76"
+source = "git+https://github.com/PistonDevelopers/interpolation#1775837859e16cc545c84b5cb4860ae25240c3e6"
 
 [[package]]
 name = "khronos_api"
 version = "0.0.5"
-source = "git+https://github.com/bjz/gl-rs#64d26f54d46640eff237db9e1aba4254ca514daf"
+source = "git+https://github.com/bjz/gl-rs#9d941381c5947bbbbe93ad6651e8eddd1c293dce"
 
 [[package]]
 name = "khronos_api"
@@ -118,33 +118,33 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num"
-version = "0.1.12"
-source = "git+https://github.com/rust-lang/num#e2f0b0d3270554d336c5908bb20a6cbbc0754e61"
+version = "0.1.14"
+source = "git+https://github.com/rust-lang/num#7c203e27d3115643c5bdc0d69e819c221f417bc4"
 dependencies = [
- "rand 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piston-texture"
 version = "0.0.1"
-source = "git+https://github.com/PistonDevelopers/texture#0380876cec71e384841d5a06ad32cb462c97be20"
+source = "git+https://github.com/pistondevelopers/texture#3cc4cddc3f8c51c36ea11dd2f63d70aa887f53fb"
 
 [[package]]
 name = "piston2d-graphics"
-version = "0.0.17"
-source = "git+https://github.com/pistondevelopers/graphics#e5c5219fbfe8aba7387c83f1eb748e73580d5b98"
+version = "0.0.18"
+source = "git+https://github.com/pistondevelopers/graphics#a103332515cc31314b3b08e32fc2881076b1e7e2"
 dependencies = [
  "interpolation 0.0.2 (git+https://github.com/PistonDevelopers/interpolation)",
- "piston-texture 0.0.1 (git+https://github.com/PistonDevelopers/texture)",
- "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
+ "piston-texture 0.0.1 (git+https://github.com/pistondevelopers/texture)",
+ "quack 0.0.12 (git+https://github.com/pistondevelopers/quack)",
  "read_color 0.0.2 (git+https://github.com/PistonDevelopers/read_color)",
- "vecmath 0.0.3 (git+https://github.com/PistonDevelopers/vecmath)",
+ "vecmath 0.0.5 (git+https://github.com/PistonDevelopers/vecmath)",
 ]
 
 [[package]]
@@ -157,28 +157,29 @@ dependencies = [
  "image 0.2.0-alpha.10 (git+https://github.com/pistondevelopers/image)",
  "khronos_api 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston-texture 0.0.1 (git+https://github.com/PistonDevelopers/texture)",
- "piston2d-graphics 0.0.17 (git+https://github.com/pistondevelopers/graphics)",
+ "piston-texture 0.0.1 (git+https://github.com/pistondevelopers/texture)",
+ "piston2d-graphics 0.0.18 (git+https://github.com/pistondevelopers/graphics)",
  "shader_version 0.0.1 (git+https://github.com/pistondevelopers/shader_version)",
 ]
 
 [[package]]
 name = "pistoncore-event"
-version = "0.0.8"
-source = "git+https://github.com/pistondevelopers/event#96afe0074416bf22478149b6a17979d633fc4375"
+version = "0.0.10"
+source = "git+https://github.com/pistondevelopers/event#6fcc26dce6e0c1eb3f3726e03fe19cf042a7f6d0"
 dependencies = [
- "pistoncore-event_loop 0.0.10 (git+https://github.com/PistonDevelopers/event_loop)",
+ "pistoncore-event_loop 0.0.13 (git+https://github.com/PistonDevelopers/event_loop)",
  "pistoncore-input 0.0.5 (git+https://github.com/pistondevelopers/input)",
- "pistoncore-window 0.0.7 (git+https://github.com/pistondevelopers/window)",
+ "pistoncore-window 0.0.10 (git+https://github.com/pistondevelopers/window)",
 ]
 
 [[package]]
 name = "pistoncore-event_loop"
-version = "0.0.10"
-source = "git+https://github.com/PistonDevelopers/event_loop#50dc05477eaccb3b64535cd17eae26e9108bd703"
+version = "0.0.13"
+source = "git+https://github.com/PistonDevelopers/event_loop#b78b297f84be4857ddc0bb4fc46cf1f8c0163356"
 dependencies = [
  "clock_ticks 0.0.2 (git+https://github.com/tomaka/clock_ticks)",
- "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
+ "pistoncore-window 0.0.10 (git+https://github.com/pistondevelopers/window)",
+ "quack 0.0.12 (git+https://github.com/pistondevelopers/quack)",
 ]
 
 [[package]]
@@ -187,30 +188,29 @@ version = "0.0.5"
 source = "git+https://github.com/pistondevelopers/input#ce3ba43c2757b20a8fc5b92e9ec388e927c451dd"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pistoncore-sdl2_window"
-version = "0.0.4"
-source = "git+https://github.com/pistondevelopers/sdl2_window#f674c7988e8c84b807b917e5b46240f0e55080d7"
+version = "0.0.5"
+source = "git+https://github.com/pistondevelopers/sdl2_window#1a4e619aee111ad2f999799001cb2525968160ba"
 dependencies = [
  "gl 0.0.8 (git+https://github.com/bjz/gl-rs)",
  "pistoncore-input 0.0.5 (git+https://github.com/pistondevelopers/input)",
- "pistoncore-window 0.0.7 (git+https://github.com/pistondevelopers/window)",
- "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
- "sdl2 0.0.25 (git+https://github.com/AngryLawyer/rust-sdl2)",
+ "pistoncore-window 0.0.10 (git+https://github.com/pistondevelopers/window)",
+ "quack 0.0.12 (git+https://github.com/pistondevelopers/quack)",
+ "sdl2 0.0.28 (git+https://github.com/AngryLawyer/rust-sdl2)",
  "shader_version 0.0.1 (git+https://github.com/pistondevelopers/shader_version)",
 ]
 
 [[package]]
 name = "pistoncore-window"
-version = "0.0.7"
-source = "git+https://github.com/pistondevelopers/window#2e743eb16a74fc8577c5779a86b6eed20fe470fd"
+version = "0.0.10"
+source = "git+https://github.com/pistondevelopers/window#4b09a0e8347618c1ba8520caa68f7dc9de18456b"
 dependencies = [
- "pistoncore-event_loop 0.0.10 (git+https://github.com/PistonDevelopers/event_loop)",
  "pistoncore-input 0.0.5 (git+https://github.com/pistondevelopers/input)",
- "quack 0.0.10 (git+https://github.com/pistondevelopers/quack)",
+ "quack 0.0.12 (git+https://github.com/pistondevelopers/quack)",
 ]
 
 [[package]]
@@ -220,21 +220,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pkg-config"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quack"
-version = "0.0.10"
-source = "git+https://github.com/pistondevelopers/quack#f0336126611d352a529ffd4e86134a7a6bcc5318"
+version = "0.0.12"
+source = "git+https://github.com/pistondevelopers/quack#6cca58761d1081f42f213510335fe100006c852a"
 
 [[package]]
 name = "rand"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -244,26 +244,26 @@ source = "git+https://github.com/PistonDevelopers/read_color#568723fb7d9a69833e1
 
 [[package]]
 name = "rustc-serialize"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sdl2"
-version = "0.0.25"
-source = "git+https://github.com/AngryLawyer/rust-sdl2#778362c9120b24ce04eaec31665e4f053ff09b2f"
+version = "0.0.28"
+source = "git+https://github.com/AngryLawyer/rust-sdl2#b94b9cb5f55f835e214a158be46da92ed97ba9ff"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sdl2-sys 0.0.25 (git+https://github.com/AngryLawyer/rust-sdl2)",
+ "rand 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sdl2-sys 0.0.27 (git+https://github.com/AngryLawyer/rust-sdl2)",
 ]
 
 [[package]]
 name = "sdl2-sys"
-version = "0.0.25"
-source = "git+https://github.com/AngryLawyer/rust-sdl2#778362c9120b24ce04eaec31665e4f053ff09b2f"
+version = "0.0.27"
+source = "git+https://github.com/AngryLawyer/rust-sdl2#b94b9cb5f55f835e214a158be46da92ed97ba9ff"
 dependencies = [
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -273,12 +273,12 @@ source = "git+https://github.com/pistondevelopers/shader_version#2186fb2098bb0d6
 
 [[package]]
 name = "vecmath"
-version = "0.0.3"
-source = "git+https://github.com/PistonDevelopers/vecmath#3080ca140d4f856b7a6ca44f88208dfacce7809c"
+version = "0.0.5"
+source = "git+https://github.com/PistonDevelopers/vecmath#6284864573fe185f4d87aadfe38d0fc3b2edcd73"
 
 [[package]]
 name = "xml-rs"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,9 +123,9 @@ fn main() {
         if let Some(args) = e.update_args() {
             vm.step(args.dt as f32);
             if vm.beeping() {
-                (*window.borrow_mut()).window.set_title(BEEP_TITLE);
+                (*window.borrow_mut()).window.set_title(BEEP_TITLE).unwrap();
             } else {
-                (*window.borrow_mut()).window.set_title(TITLE);
+                (*window.borrow_mut()).window.set_title(TITLE).unwrap();
             }
         }
         if let Some(args) = e.render_args() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@
 #![feature(env)]
 #![feature(io)]
 #![feature(path)]
+#![feature(os)]
+#![feature(fs)]
 
 extern crate shader_version;
 extern crate input;
@@ -24,8 +26,8 @@ use opengl_graphics::{
 };
 
 use std::env;
-use std::old_io::File;
-use std::old_io::BufReader;
+use std::io::{Read, BufReader};
+use std::fs::File;
 // use std::time::duration::Duration;
 use quack::Set;
 // use input::keyboard::Key;
@@ -51,9 +53,9 @@ fn main() {
         }
     }
 
-    let intro_reader = &mut BufReader::new(INTRO_ROM) as &mut Reader;
+    let intro_reader = &mut BufReader::new(INTRO_ROM) as &mut Read;
     let mut rom_reader = match &mut rom {
-        &mut Some(ref mut r) => r as &mut Reader,
+        &mut Some(ref mut r) => r as &mut Read,
         _ => {
             println!("You can provide a path to a chip8 binary to interpret it.");
             intro_reader

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@
 #![feature(env)]
 #![feature(io)]
 #![feature(path)]
-#![feature(os)]
 #![feature(fs)]
 
 extern crate shader_version;
@@ -28,6 +27,7 @@ use opengl_graphics::{
 use std::env;
 use std::io::{Read, BufReader};
 use std::fs::File;
+use std::path::Path;
 // use std::time::duration::Duration;
 use quack::Set;
 // use input::keyboard::Key;


### PR DESCRIPTION
This is a work-in-progress to port the code to the new `std::io` module.

Note that [`std::io`](http://doc.rust-lang.org/std/io/index.html) itself contains the following warning:

> **NOTE**: This module is very much a work in progress and is under active development. At this time it is still recommended to use the `old_io` module while the details of this module shake out.

As such, do not merge until the dust has settled :hand: 
