### PR TITLE
Add `Register` enum for `Vx` and `Vy`

### DIFF
--- a/chip8_vm/src/instructions.rs
+++ b/chip8_vm/src/instructions.rs
@@ -1,11 +1,45 @@
 //! Raw and high-level instruction abstractions
 
-/// First register in an opcode
+use std::num::{FromPrimitive, ToPrimitive};
+
+/// A register index/name
 ///
 /// There are 16 registers, `V0`..`VF`
-pub type Vx = u8;
+#[derive(FromPrimitive, Copy, Debug)]
+pub enum Register {
+    V0 = 0x0,
+    V1 = 0x1,
+    V2 = 0x2,
+    V3 = 0x3,
+    V4 = 0x4,
+    V5 = 0x5,
+    V6 = 0x6,
+    V7 = 0x7,
+    V8 = 0x8,
+    V9 = 0x9,
+    VA = 0xA,
+    VB = 0xB,
+    VC = 0xC,
+    VD = 0xD,
+    VE = 0xE,
+    VF = 0xF,
+}
+
+impl ToPrimitive for Register {
+    fn to_i64(&self) -> Option<i64> {
+        Some(*self as i64)
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        Some(*self as u64)
+    }
+}
+
+/// First register in an opcode
+pub type Vx = Register;
 /// Second register in an opcode
-pub type Vy = u8;
+pub type Vy = Register;
+
 /// A byte
 ///
 /// Valid values are within `0x0` .. `0xFF`.
@@ -69,12 +103,12 @@ impl RawInstruction {
 
     /// The *`Vx` register-index* part, i.e. `0xE` is `VE`
     pub fn x(&self) -> Vx {
-        ((self.bits & 0x0F00) >> 8) as u8
+        FromPrimitive::from_u8(((self.bits & 0x0F00) >> 8) as u8).unwrap()
     }
 
     /// The *`Vy` register-index* part, i.e. `0xE` is `VE`
     pub fn y(&self) -> Vy {
-        ((self.bits & 0x00F0) >> 4) as u8
+        FromPrimitive::from_u8(((self.bits & 0x00F0) >> 4) as u8).unwrap()
     }
 
     /// The *high nibble* part


### PR DESCRIPTION
As commented in #19, this replaces the `u8` of `Vx`/`Vy` with an `enum Register`, so they can only take valid values as well as providing names for the registers themselves.

The implementation is debatable, as it uses unstable traits. I also made an alternative implementation writing manual `Register::from_idx()` and `Register::idx()` functions, which is slightly more verbose.
